### PR TITLE
Two fix about increased limits not working properly (and still increase the limit higher too)

### DIFF
--- a/t4m/PatchT4E_Render.cpp
+++ b/t4m/PatchT4E_Render.cpp
@@ -6,7 +6,7 @@
 typedef void*(__cdecl* R_CreateDynamicBuffersT)();
 R_CreateDynamicBuffersT R_CreateDynamicBuffers = nullptr;
 
-constexpr uint32_t MB_SIZE = 104857;
+constexpr uint32_t MB_SIZE = 1048576; // 1 MB
 
 using namespace Memory::VP;
 
@@ -23,37 +23,45 @@ dvar_t* r_buf_preTessIndexBuffer = nullptr;
 void* __cdecl R_CreateDynamicBuffers_hook() {
 	if (r_increase_render_buffers && r_increase_render_buffers->current.boolean) {
 		if (r_buf_dynamicVertexBuffer) {
-			// Default 1 MB
-			Patch<uint32_t>((0x0070EC1A + 3), r_buf_dynamicVertexBuffer->current.integer * MB_SIZE);
-			Patch<uint32_t>((0x0070EC42), r_buf_dynamicVertexBuffer->current.integer * MB_SIZE);
-			Patch<uint32_t>((0x70ED2C + 1), r_buf_dynamicVertexBuffer->current.integer * MB_SIZE);
+			// Original: 1 MB. Patches capacity field + D3D size + error message.
+			const uint32_t vbSize = r_buf_dynamicVertexBuffer->current.integer * MB_SIZE;
+
+			Patch<uint32_t>((0x0070EC1A + 3), vbSize); 
+			Patch<uint32_t>((0x0070EC42),      vbSize); 
+			Patch<uint32_t>((0x70ED2C  + 1),   vbSize); 
 		}
 
 		if (r_buf_skinnedCacheVb) {
-			// default 60 MB?
-			Patch<uint32_t>((0x0070EC77 + 1), r_buf_skinnedCacheVb->current.integer * MB_SIZE);
+			// Original: 6 MB. Two D3D vertex buffers + allocator soft/hard limits.
+			// Soft limit = size * (9/13) ≈ 69.2% — matches the original nullsub_2 address ratio.
+			// FPU soft limit ratio: 5347738.0 / 6291456.0 ≈ 85% of hard limit.
+			const uint32_t skinnedSize = r_buf_skinnedCacheVb->current.integer * MB_SIZE;
 
-			Patch<uint32_t>((0x71DD7C + 2), ((uint32_t)((float)(r_buf_skinnedCacheVb->current.integer * MB_SIZE) / 1.44444444f))); // ok this idk f why
-			Patch<uint32_t>((0x71DD95 + 2), r_buf_skinnedCacheVb->current.integer * MB_SIZE);
+			Patch<uint32_t>((0x0070EC77 + 1), skinnedSize); 
+			Patch<uint32_t>((0x71DD7C  + 2),  (uint32_t)((float)skinnedSize / 1.44444444f)); 
+			Patch<uint32_t>((0x71DD95  + 2),  skinnedSize); 
+			Patch<float>   (0x8AF24C,          (float)skinnedSize * (5347738.0f / 6291456.0f)); 
 		}
 
 		if (r_buf_tempSkin) {
-			// default 60 MB?
-			Patch<uint32_t>((0x6F52A7 + 1), r_buf_tempSkin->current.integer * MB_SIZE);
-
+			// Original: 6 MB. VirtualAlloc'd CPU memory for skinned mesh temp storage.
+			Patch<uint32_t>((0x6F52A7 + 1), r_buf_tempSkin->current.integer * MB_SIZE); 
 		}
 
 		if (r_buf_dynamicIndexBuffer) {
-			// default 2 MB
-			Patch<uint32_t>((0x70ECF8 + 3), (r_buf_dynamicIndexBuffer->current.integer * MB_SIZE) / 2); // idk why
-			Patch<uint32_t>((0x70EDA6 + 1), r_buf_dynamicIndexBuffer->current.integer * MB_SIZE);
-			Patch<uint32_t>((0x70EE1E + 1), r_buf_dynamicIndexBuffer->current.integer * MB_SIZE);
+			// Original: 2 MB D3D buffer. Capacity field stores index count (size/2 for D3DFMT_INDEX16).
+			const uint32_t ibSize = r_buf_dynamicIndexBuffer->current.integer * MB_SIZE;
+			
+			Patch<uint32_t>((0x70ECF8 + 3), ibSize / 2); 
+			Patch<uint32_t>((0x70EDA6 + 1), ibSize);     
+			Patch<uint32_t>((0x70EE1E + 1), ibSize);     
 		}
 
 		//if (r_buf_preTessIndexBuffer) {
-		//	// default 2 MB
-		//	Patch<uint32_t>((0x0070EDEA + 3), (r_buf_preTessIndexBuffer->current.integer * MB_SIZE) / 2); // idk why
-		//	Patch<uint32_t>((0x70EE7D + 1), r_buf_preTessIndexBuffer->current.integer * MB_SIZE);
+		//	// Original: 2 MB D3D buffer. Same layout as dynamicIndexBuffer.
+		//	const uint32_t ptibSize = r_buf_preTessIndexBuffer->current.integer * MB_SIZE;
+		//	Patch<uint32_t>((0x0070EDEA + 3), ptibSize / 2); 
+		//	Patch<uint32_t>((0x70EE7D  + 1),  ptibSize);     
 		//}
 	}
 	return R_CreateDynamicBuffers();
@@ -275,11 +283,13 @@ void PatchT4E_Render() {
 		0,
 		"z position FOV offset compensation of the viewmodel");
 
-	r_buf_skinnedCacheVb = Dvar_RegisterInt(120, "r_buf_skinnedCacheVb", 60, 512, DVAR_FLAG_ARCHIVE | DVAR_FLAG_LATCH);
-	r_buf_tempSkin = Dvar_RegisterInt(120, "r_buf_tempSkin", 60, 512, DVAR_FLAG_ARCHIVE | DVAR_FLAG_LATCH );
-	r_buf_dynamicVertexBuffer = Dvar_RegisterInt(3, "r_buf_dynamicVertexBuffer", 1, 16, DVAR_FLAG_ARCHIVE | DVAR_FLAG_LATCH);
-	r_buf_dynamicIndexBuffer = Dvar_RegisterInt(4, "r_buf_dynamicIndexBuffer", 2, 16, DVAR_FLAG_ARCHIVE | DVAR_FLAG_LATCH );
-	r_buf_preTessIndexBuffer = Dvar_RegisterInt(4, "r_buf_preTessIndexBuffer", 2, 16, DVAR_FLAG_ARCHIVE | DVAR_FLAG_LATCH );
+	// Units are MB. Minimums correspond to original game buffer sizes.
+	// Defaults are 2x original to provide a meaningful increase.
+	r_buf_skinnedCacheVb        = Dvar_RegisterInt(12, "r_buf_skinnedCacheVb",        6,  64, DVAR_FLAG_ARCHIVE | DVAR_FLAG_LATCH); // orig: 6 MB
+	r_buf_tempSkin              = Dvar_RegisterInt(12, "r_buf_tempSkin",              6,  64, DVAR_FLAG_ARCHIVE | DVAR_FLAG_LATCH); // orig: 6 MB
+	r_buf_dynamicVertexBuffer   = Dvar_RegisterInt(2,  "r_buf_dynamicVertexBuffer",   1,  16, DVAR_FLAG_ARCHIVE | DVAR_FLAG_LATCH); // orig: 1 MB
+	r_buf_dynamicIndexBuffer    = Dvar_RegisterInt(4,  "r_buf_dynamicIndexBuffer",    2,  16, DVAR_FLAG_ARCHIVE | DVAR_FLAG_LATCH); // orig: 2 MB
+	r_buf_preTessIndexBuffer    = Dvar_RegisterInt(4,  "r_buf_preTessIndexBuffer",    2,  16, DVAR_FLAG_ARCHIVE | DVAR_FLAG_LATCH); // orig: 2 MB
 
 	r_increase_render_buffers = Dvar_RegisterBool(true, "r_increase_render_buffers", DVAR_FLAG_ARCHIVE | DVAR_FLAG_LATCH, "increasing rendering buffers");
 

--- a/t4m/PatchT4MemoryLimits.cpp
+++ b/t4m/PatchT4MemoryLimits.cpp
@@ -1,4 +1,4 @@
-// ==========================================================
+﻿// ==========================================================
 // T4M project
 // 
 // Component: clientdll
@@ -11,23 +11,100 @@
 
 #include "StdInc.h"
 
+#define NEW_ASSET_ENTRY_POOL_SIZE 65535
+#define NEW_IMAGE_SORT_BUFFER_SIZE 8192
+
 void PatchT4_MemoryLimits()
 {
 	// increase pool sizes to similar (or greater) t5 sizes.
-	DB_ReallocXAssetPool(ASSET_TYPE_FX, 600);
-	DB_ReallocXAssetPool(ASSET_TYPE_IMAGE, 4096);
-	DB_ReallocXAssetPool(ASSET_TYPE_LOADED_SOUND, 2400);
+	DB_ReallocXAssetPool(ASSET_TYPE_FX, 2048);
+	DB_ReallocXAssetPool(ASSET_TYPE_IMAGE, NEW_IMAGE_SORT_BUFFER_SIZE);
+	DB_ReallocXAssetPool(ASSET_TYPE_LOADED_SOUND, 4096);
 	DB_ReallocXAssetPool(ASSET_TYPE_MATERIAL, 4096);
-	DB_ReallocXAssetPool(ASSET_TYPE_WEAPON, 320);
-	DB_ReallocXAssetPool(ASSET_TYPE_XMODEL, 1500);
+	DB_ReallocXAssetPool(ASSET_TYPE_WEAPON, 512);
+	DB_ReallocXAssetPool(ASSET_TYPE_XMODEL, 4096);
+	DB_ReallocXAssetPool(ASSET_TYPE_RAWFILE, 2048);
+	DB_ReallocXAssetPool(ASSET_TYPE_PHYSCONSTRAINTS, 256);
+	DB_ReallocXAssetPool(ASSET_TYPE_PHYSPRESET, 256);
+	DB_ReallocXAssetPool(ASSET_TYPE_XMODELPIECES, 256);
 
 	// change the size of g_mem from 0x12C00000 to 0x19600000, UGX-Mod v1.1 is pretty fucking huge
 	// had to increase due to it crashing in Com_BeginParseSession
-	*(DWORD*)0x5F5492 = 0x19600000; //0x14800000
-	*(DWORD*)0x5F54D1 = 0x19600000; //0x14800000
-	*(DWORD*)0x5F54DB = 0x19600000; //0x14800000
+	*(DWORD*)0x5F5492 = 0x40000000; //0x14800000
+	*(DWORD*)0x5F54D1 = 0x40000000; //0x14800000
+	*(DWORD*)0x5F54DB = 0x40000000; //0x14800000
+
+	//*(DWORD*)0x5F5492 = 0x26100000; //0x14800000
+	//*(DWORD*)0x5F54D1 = 0x26100000; //0x14800000
+	//*(DWORD*)0x5F54DB = 0x26100000; //0x14800000
 
 	// change the num of entities available to be spawned in G_Spawn from 1022 to 1500
 	// still a W.I.P. is missing array and hash table(?) changes
 	//PatchMemory(0x0054EAC3, (PBYTE)"\xDC\x05", 2);
+
+	// =====================================================================
+	// For the record what is this things :  
+	// Fix renderer image sort array overflow
+	// R_LoadWorld and sub_719F40 call sub_48DF60
+	// to fill dword_3BF1880[] with image asset headers, then sort them.
+	// The array is hardcoded for 0x800 (2048) entries, but since we increases the
+	// image pool to 8192. sub_48DF60 has NO bounds check — it writes ALL
+	// matching assets, overflowing the buffer and corrupting:
+	//   - dword_3BF3884 (image count, at array + 0x2004)
+	//   - dword_3BF392C (scene structure pointer, at array + 0x20AC)
+	// This causes both observed crashes via xdbg:
+	//   0x719A2E: sort comparator gets garbage → access violation
+	//   0x491500: corrupted scene pointer → bitfield access violation
+	//
+	// =====================================================================
+
+	// Allocate new image sort buffer + count variable (contiguous)
+	static DWORD* newImageBuffer = (DWORD*)VirtualAlloc(
+		NULL,
+		NEW_IMAGE_SORT_BUFFER_SIZE * sizeof(DWORD) + sizeof(DWORD), // array + count
+		MEM_COMMIT | MEM_RESERVE,
+		PAGE_READWRITE);
+
+	if (!newImageBuffer) {
+		Com_Printf(0, "^1ERROR: Failed to allocate expanded image sort buffer\n");
+		return;
+	}
+
+	DWORD newImgBufAddr = (DWORD)newImageBuffer;
+	// Place the count variable right after the array, mirroring original layout
+	// Original: array at 0x3BF1880, count at 0x3BF3884 (offset +0x2004 from array, but
+	// we just need a separate DWORD for the count — any stable address works)
+	DWORD* newImageCount = &newImageBuffer[NEW_IMAGE_SORT_BUFFER_SIZE];
+	DWORD newImgCntAddr = (DWORD)newImageCount;
+
+	DWORD oldProtect2;
+	VirtualProtect((LPVOID)0x6D69E0, 0x742012 - 0x6D69E0, PAGE_EXECUTE_READWRITE, &oldProtect2);
+
+	// --- Patch 12 references to dword_3BF1880 (image sort array) ---
+
+	*(DWORD*)0x6D69EB = newImgBufAddr;
+	*(DWORD*)0x6DC964 = newImgBufAddr;
+	*(DWORD*)0x6DCA8C = newImgBufAddr;
+	*(DWORD*)0x6E993D = newImgBufAddr;
+	*(DWORD*)0x705784 = newImgBufAddr;
+	*(DWORD*)0x70579F = newImgBufAddr;
+	*(DWORD*)0x719F52 = newImgBufAddr;
+	*(DWORD*)0x719F6D = newImgBufAddr;
+	*(DWORD*)0x741C11 = newImgBufAddr;
+	*(DWORD*)0x741C98 = newImgBufAddr;
+	*(DWORD*)0x741EB7 = newImgBufAddr;
+	*(DWORD*)0x74200E = newImgBufAddr;
+
+	// --- Patch 9 references to dword_3BF3884 (image count) ---
+
+	*(DWORD*)0x6E990F = newImgCntAddr;
+	*(DWORD*)0x6E9936 = newImgCntAddr;
+	*(DWORD*)0x6E9942 = newImgCntAddr;
+	*(DWORD*)0x6E995A = newImgCntAddr;
+	*(DWORD*)0x6E9D3C = newImgCntAddr;
+	*(DWORD*)0x705793 = newImgCntAddr;
+	*(DWORD*)0x705799 = newImgCntAddr;
+	*(DWORD*)0x719F61 = newImgCntAddr;
+	*(DWORD*)0x719F67 = newImgCntAddr;
+
 }

--- a/t4m/PatchT4MemoryLimits.cpp
+++ b/t4m/PatchT4MemoryLimits.cpp
@@ -34,10 +34,6 @@ void PatchT4_MemoryLimits()
 	*(DWORD*)0x5F54D1 = 0x40000000; //0x14800000
 	*(DWORD*)0x5F54DB = 0x40000000; //0x14800000
 
-	//*(DWORD*)0x5F5492 = 0x26100000; //0x14800000
-	//*(DWORD*)0x5F54D1 = 0x26100000; //0x14800000
-	//*(DWORD*)0x5F54DB = 0x26100000; //0x14800000
-
 	// change the num of entities available to be spawned in G_Spawn from 1022 to 1500
 	// still a W.I.P. is missing array and hash table(?) changes
 	//PatchMemory(0x0054EAC3, (PBYTE)"\xDC\x05", 2);


### PR DESCRIPTION
Hello, i have came across via my fork that there is some problem on T4M regarding the expanded limit.
First, a bug present since the begining, the image count has a fixed size of 2048, so even if we expand the limit of via the reallocXDBAsset, the game will still crash because the memory will be broken.
The second bug was introduced in the r49 version. The buffer change doesn't really work well. I have came across this problem in two custom maps, Train Dead ( https://callofdutyrepo.com/2019/08/03/train-dead/ ) and the custom singleplayer level "The Final Stand" (https://www.youtube.com/watch?v=AZzmKhIgao4 ) with the return of the directX crash and/or the vertex corruption, which shouldn't exist anymore.
In fact the problem reside, in the incorrect value of the MB_SIZE, which was missing it's final 6, to make 1048576, the correct value of 1MB.
I won't lie about it, because i prefer to be honest, but i know the absolute minimal of Assembly language, and understanding what's happening on a dessambled .exe, is also quite a tricky job, so i have used AI (Claude Code to be more precise) to help fix these issue, i'll completly understand if you won't approve these change but i still need to find a way to tell you these discoveries !

Still, i hope it will help further the CoD WaW modding community with more possibilities ahead ! 